### PR TITLE
fix: impl default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,12 @@ pub struct BigInt {
     digits: Vec<u32>, // little endian; digits[0] is least significat limb
 }
 
+impl Default for BigInt {
+    fn default() -> Self {
+        BigInt::zero()
+    }
+}
+
 impl BigInt {
     pub fn zero() -> Self {
         Self {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `BigInt` now supports the `Default` trait, allowing instances to be initialized with default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->